### PR TITLE
Hotfix: Add support for Python 3.8

### DIFF
--- a/celery_aio_pool/__init__.py
+++ b/celery_aio_pool/__init__.py
@@ -11,7 +11,7 @@ from celery_aio_pool.pool import AsyncIOPool
 from celery_aio_pool.tracer import build_async_tracer
 
 __pkg_name__ = "celery-aio-pool"
-__version__ = "0.1.0-rc.5"  # x-release-please-version
+__version__ = "0.1.0-rc.7"  # x-release-please-version
 
 __all__ = (
     "AsyncIOPool",

--- a/celery_aio_pool/pool.py
+++ b/celery_aio_pool/pool.py
@@ -54,9 +54,7 @@ WorkerPoolInfo = Dict[
 ]
 
 # test if aio.to_thread exists and if not - override it
-try:
-    aio.to_thread
-except AttributeError:
+if not callable(getattr(aio, "to_thread", None)):
     import contextvars
     import functools
 

--- a/celery_aio_pool/pool.py
+++ b/celery_aio_pool/pool.py
@@ -15,6 +15,8 @@ from typing import (
     Callable,
     Optional,
     Union,
+    Dict,
+    Tuple,
 )
 
 # Third-Party Imports
@@ -39,13 +41,13 @@ from celery_aio_pool.types import (
 __all__ = ("AsyncIOPool",)
 
 
-WorkerPoolInfo = dict[
+WorkerPoolInfo = Dict[
     str,
     Optional[
         Union[
             int,
             bool,
-            tuple[int, ...],
+            Tuple[int, ...],
             aio.AbstractEventLoop,
         ]
     ],

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -27,6 +27,7 @@ classifiers = [
   "Development Status :: 4 - Beta",
   "Programming Language :: Python",
   "Intended Audience :: Developers",
+  "Programming Language :: Python :: 3.8",
   "Programming Language :: Python :: 3.9",
   "Programming Language :: Python :: 3.10",
   "Programming Language :: Python :: 3.11",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -43,10 +43,6 @@ python = ">=3.8,<3.13"
 # Core project dependencies
 celery = "^5"
 
-# Dependencies specific to Python 3.8
-contextvars = { version = "*", python = "3.8" }
-functools = { version = "*", python = "3.8" }
-
 
 [tool.poetry.group.dev.dependencies]
 # Formatting & Linting

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -42,6 +42,10 @@ python = ">=3.8,<3.13"
 # Core project dependencies
 celery = "^5"
 
+# Dependencies specific to Python 3.8
+contextvars = { version = "*", python = "3.8" }
+functools = { version = "*", python = "3.8" }
+
 
 [tool.poetry.group.dev.dependencies]
 # Formatting & Linting


### PR DESCRIPTION
i've been on `py38` and used old celery-pool plugin, but then tried this one and it works nice (despite lack of `concurrency` support) after i made some modifications to code ;)

so, the recent `rc6` adds support for `py312`, but still lists `py38` as supported
```
[tool.poetry.dependencies]
# Supported Python versions
python = ">=3.8,<3.13"
```

to add support for py38 the changes were quite trivial (except 1 method)

let me know what you think about this PR

